### PR TITLE
Add auto-shutdown configuration.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,3 +52,5 @@ job:
         --allow-root
         --NotebookApp.token=
         --notebook-dir=/project/notebooks
+        --NotebookApp.shutdown_no_activity_timeout=7200
+        --MappingKernelManager.cull_idle_timeout=7200


### PR DESCRIPTION
We previously had this feature but at some point in time, it was lost.
However, we still have it in our [web app](https://github.com/neuro-inc/platform-pipelines/blob/d286c1ff22251c80f2e8ded46b63ed95b22383a2/platform_pipelines/config.py#L72).

Let's return it back into neuro-flow action.